### PR TITLE
plugin: Make mechanics plugin and shm element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "mechanics"
+version = "0.2.0"
+dependencies = [
+ "log",
+ "physim-core",
+ "physim_attribute",
+ "rand",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [ "astro","physim-core","glrender", "physim_attribute", "debug", "integrators", "utilities"]
+members = [ "astro","physim-core","glrender", "physim_attribute", "debug", "integrators", "utilities", "mechanics"]
 
 [workspace.package]
 authors = ["Joseph Briggs <jhbriggs23@gmail.com>"]

--- a/example_pipelines/shm.toml
+++ b/example_pipelines/shm.toml
@@ -1,0 +1,21 @@
+[global]
+dt = 0.001
+iterations = 15000
+
+[elements]
+
+[[elements.cube]]
+n = 2000
+seed = 2
+a = 1.0
+
+[[elements.msgdebug]]
+
+[[elements.rk4]]
+
+[[elements.shm]]
+c=0.0
+
+[[elements.glrender]]
+resolution="1080p"
+shader="velocity"

--- a/mechanics/Cargo.toml
+++ b/mechanics/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "mechanics"
+edition = "2024"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]
+physim-core = { path = "../physim-core" }
+physim_attribute = { path = "../physim_attribute" }
+serde_json = "1.0.140"
+serde = {version="1.0.219",features = ["derive"]}
+rand = "0.9.1"
+log = "0.4.27"

--- a/mechanics/src/lib.rs
+++ b/mechanics/src/lib.rs
@@ -1,0 +1,7 @@
+#![feature(str_from_raw_parts)]
+
+use physim_core::register_plugin;
+
+mod shm;
+
+register_plugin!("shm");

--- a/mechanics/src/shm.rs
+++ b/mechanics/src/shm.rs
@@ -1,0 +1,117 @@
+use std::{collections::HashMap, sync::Mutex};
+
+use physim_attribute::transform_element;
+use physim_core::{Entity, Force, messages::MessageClient, plugin::transform::TransformElement};
+use serde_json::Value;
+
+enum ShmTransformMode {
+    GlobalCentre,
+    ParticleCentre,
+}
+
+#[transform_element(
+    name = "shm",
+    blurb = "Make all entities into simple harmonic oscillators"
+)]
+pub struct ShmTransform {
+    inner: Mutex<ShmTransformInner>,
+}
+
+struct ShmTransformInner {
+    origins: Vec<[f32; 3]>,
+    k: f32,
+    c: f32,
+    mode: ShmTransformMode,
+}
+
+impl TransformElement for ShmTransform {
+    fn transform(&self, state: &[Entity], forces: &mut [Force]) {
+        let mut inner = self.inner.lock().unwrap();
+        match inner.mode {
+            ShmTransformMode::GlobalCentre => inner.global_centre_transform(state, forces),
+            ShmTransformMode::ParticleCentre => inner.particle_centre_transform(state, forces),
+        }
+    }
+
+    fn new(properties: HashMap<String, Value>) -> Self {
+        let k: f32 = properties.get("k").and_then(|x| x.as_f64()).unwrap_or(1.0) as f32;
+        let c: f32 = properties.get("c").and_then(|x| x.as_f64()).unwrap_or(0.0) as f32;
+
+        let mode: ShmTransformMode = properties
+            .get("mode")
+            .and_then(|x| x.as_str())
+            .map(|mode_str| match mode_str {
+                "centre" => ShmTransformMode::GlobalCentre,
+                "particle" => ShmTransformMode::ParticleCentre,
+                _ => ShmTransformMode::GlobalCentre,
+            })
+            .unwrap_or(ShmTransformMode::GlobalCentre);
+
+        ShmTransform {
+            inner: Mutex::new(ShmTransformInner {
+                origins: vec![],
+                k,
+                c,
+                mode,
+            }),
+        }
+    }
+
+    fn set_properties(&self, _properties: HashMap<String, Value>) {}
+
+    fn get_property(&self, _prop: &str) -> Result<Value, Box<dyn std::error::Error>> {
+        Err("No property".into())
+    }
+
+    fn get_property_descriptions(&self) -> HashMap<String, String> {
+        HashMap::from([
+            (
+                String::from("k"),
+                String::from("Spring constant. Default=1.0"),
+            ),
+            (
+                String::from("c"),
+                String::from("Damping coefficient. Default=0.0"),
+            ),
+            (
+                String::from("mode"),
+                String::from("Either 'centre' or 'particle'. Defaults to centre"),
+            ),
+        ])
+    }
+}
+
+impl MessageClient for ShmTransform {}
+
+impl ShmTransformInner {
+    fn global_centre_transform(&self, state: &[Entity], forces: &mut [Force]) {
+        for (f, entity) in forces.iter_mut().zip(state) {
+            *f += Force {
+                fx: -self.k * entity.x - self.c * entity.vx,
+                fy: -self.k * entity.y - self.c * entity.vy,
+                fz: -self.k * entity.z - self.c * entity.vz,
+            };
+        }
+    }
+
+    fn particle_centre_transform(&mut self, state: &[Entity], forces: &mut [Force]) {
+        if self.origins.len() != state.len() {
+            self.origins = state.iter().map(|e| [e.x, e.y, e.z]).collect();
+        }
+
+        let deltas: Vec<[f32; 3]> = self
+            .origins
+            .iter()
+            .zip(state)
+            .map(|(a, b)| [b.x - a[0], b.y - a[1], b.z - a[2]])
+            .collect();
+
+        for (f, (delta, entity)) in forces.iter_mut().zip(deltas.iter().zip(state)) {
+            *f += Force {
+                fx: -self.k * delta[0] - self.c * entity.vx,
+                fy: -self.k * delta[1] - self.c * entity.vy,
+                fz: -self.k * delta[2] - self.c * entity.vz,
+            };
+        }
+    }
+}


### PR DESCRIPTION
The mechanics plugin is the designated plugin for elements which are fairly generic "physics". These elements should be the types of stuff you'd encounter on a physics course in classical mechanics. I think elastic collisions could be put here as well. I wanted to keep these distinct from the astro plugin since it has initialisers which are specific to astrophyics.