### PR TITLE
refactor!: change force to acceleration in core

### DIFF
--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -13,7 +13,7 @@ use physim_attribute::{
     initialise_state_element, render_element, synth_element, transform_element, transmute_element,
 };
 use physim_core::{
-    Entity, Force,
+    Acceleration, Entity,
     messages::{MessageClient, MessagePriority},
     msg,
     plugin::{
@@ -95,9 +95,9 @@ pub struct DebugTransform {
 }
 
 impl TransformElement for DebugTransform {
-    fn transform(&self, _: &[Entity], forces: &mut [Force]) {
-        for f in forces {
-            *f += Force::default();
+    fn transform(&self, _: &[Entity], acceleration: &mut [Acceleration]) {
+        for a in acceleration {
+            *a += Acceleration::default();
         }
 
         let msg1 = msg!(self, "debugplugin", "transformed", MessagePriority::Low);

--- a/integrators/src/euler.rs
+++ b/integrators/src/euler.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use physim_attribute::integrator_element;
 use physim_core::{
-    Force,
+    Acceleration,
     messages::MessageClient,
     plugin::{Element, ElementCreator, integrator::IntegratorElement},
 };
@@ -19,25 +19,22 @@ impl IntegratorElement for Euler {
         &self,
         entities: &[physim_core::Entity],
         new_state: &mut [physim_core::Entity],
-        force_fn: &dyn Fn(&[physim_core::Entity], &mut [Force]),
+        acc_fn: &dyn Fn(&[physim_core::Entity], &mut [Acceleration]),
         dt: f64,
     ) {
-        let mut forces = vec![Force::zero(); entities.len()];
-        force_fn(entities, &mut forces);
+        let mut accelerations = vec![Acceleration::zero(); entities.len()];
+        acc_fn(entities, &mut accelerations);
 
-        for (idx, (entity, f)) in entities.iter().zip(forces).enumerate() {
-            let m = entity.mass;
-            // f = ma
-            let a = [f.fx / m, f.fy / m, f.fz / m];
+        for (idx, (entity, a)) in entities.iter().zip(accelerations).enumerate() {
             // S = s0 + ut + 1/2 a t^2
-            let x = entity.x + entity.vx * dt + 0.5 * a[0] * (dt.powi(2));
-            let y = entity.y + entity.vy * dt + 0.5 * a[1] * (dt.powi(2));
-            let z = entity.z + entity.vz * dt + 0.5 * a[2] * (dt.powi(2));
+            let x = entity.x + entity.vx * dt + 0.5 * a.x * (dt.powi(2));
+            let y = entity.y + entity.vy * dt + 0.5 * a.y * (dt.powi(2));
+            let z = entity.z + entity.vz * dt + 0.5 * a.z * (dt.powi(2));
 
             // v = v0 +
-            let vx = entity.vx + a[0] * dt;
-            let vy = entity.vy + a[1] * dt;
-            let vz = entity.vz + a[2] * dt;
+            let vx = entity.vx + a.x * dt;
+            let vy = entity.vy + a.y * dt;
+            let vz = entity.vz + a.z * dt;
 
             let mut new_entity = *entity;
             new_entity.x = x;

--- a/integrators/src/rk4.rs
+++ b/integrators/src/rk4.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Mutex};
 
 use physim_attribute::integrator_element;
 use physim_core::{
-    Entity, Force,
+    Acceleration, Entity,
     messages::MessageClient,
     plugin::{Element, ElementCreator, integrator::IntegratorElement},
 };
@@ -26,26 +26,26 @@ impl IntegratorElement for Rk4 {
         &self,
         entities: &[physim_core::Entity],
         new_state: &mut [physim_core::Entity],
-        force_fn: &dyn Fn(&[Entity], &mut [Force]),
+        acc_fn: &dyn Fn(&[Entity], &mut [Acceleration]),
         dt: f64,
     ) {
         let n = entities.len();
 
         // --- k1 ---
-        let mut f1 = vec![Force::zero(); n];
-        force_fn(entities, &mut f1);
+        let mut f1 = vec![Acceleration::zero(); n];
+        acc_fn(entities, &mut f1);
 
         let k1: Vec<Entity> = entities
             .iter()
             .cloned()
             .zip(&f1)
-            .map(|(e, f)| Entity {
+            .map(|(e, a)| Entity {
                 x: dt * e.vx,
                 y: dt * e.vy,
                 z: dt * e.vz,
-                vx: dt * f.fx / e.mass,
-                vy: dt * f.fy / e.mass,
-                vz: dt * f.fz / e.mass,
+                vx: dt * a.x,
+                vy: dt * a.y,
+                vz: dt * a.z,
                 ..e
             })
             .collect();
@@ -66,20 +66,20 @@ impl IntegratorElement for Rk4 {
             })
             .collect();
 
-        let mut f2 = vec![Force::zero(); n];
-        force_fn(&temp_ents, &mut f2);
+        let mut f2 = vec![Acceleration::zero(); n];
+        acc_fn(&temp_ents, &mut f2);
 
         let k2: Vec<Entity> = temp_ents
             .iter()
             .cloned()
             .zip(&f2)
-            .map(|(e, f)| Entity {
+            .map(|(e, a)| Entity {
                 x: dt * e.vx,
                 y: dt * e.vy,
                 z: dt * e.vz,
-                vx: dt * f.fx / e.mass,
-                vy: dt * f.fy / e.mass,
-                vz: dt * f.fz / e.mass,
+                vx: dt * a.x,
+                vy: dt * a.y,
+                vz: dt * a.z,
                 ..e
             })
             .collect();
@@ -100,20 +100,20 @@ impl IntegratorElement for Rk4 {
             })
             .collect();
 
-        let mut f3 = vec![Force::zero(); n];
-        force_fn(&temp_ents, &mut f3);
+        let mut f3 = vec![Acceleration::zero(); n];
+        acc_fn(&temp_ents, &mut f3);
 
         let k3: Vec<Entity> = temp_ents
             .iter()
             .cloned()
             .zip(&f3)
-            .map(|(e, f)| Entity {
+            .map(|(e, a)| Entity {
                 x: dt * e.vx,
                 y: dt * e.vy,
                 z: dt * e.vz,
-                vx: dt * f.fx / e.mass,
-                vy: dt * f.fy / e.mass,
-                vz: dt * f.fz / e.mass,
+                vx: dt * a.x,
+                vy: dt * a.y,
+                vz: dt * a.z,
                 ..e
             })
             .collect();
@@ -134,20 +134,20 @@ impl IntegratorElement for Rk4 {
             })
             .collect();
 
-        let mut f4 = vec![Force::zero(); n];
-        force_fn(&temp_ents, &mut f4);
+        let mut f4 = vec![Acceleration::zero(); n];
+        acc_fn(&temp_ents, &mut f4);
 
         let k4: Vec<Entity> = temp_ents
             .iter()
             .cloned()
             .zip(&f4)
-            .map(|(e, f)| Entity {
+            .map(|(e, a)| Entity {
                 x: dt * e.vx,
                 y: dt * e.vy,
                 z: dt * e.vz,
-                vx: dt * f.fx / e.mass,
-                vy: dt * f.fy / e.mass,
-                vz: dt * f.fz / e.mass,
+                vx: dt * a.x,
+                vy: dt * a.y,
+                vz: dt * a.z,
                 ..e
             })
             .collect();

--- a/integrators/src/verlet.rs
+++ b/integrators/src/verlet.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Mutex};
 
 use physim_attribute::integrator_element;
 use physim_core::{
-    Entity, Force,
+    Acceleration, Entity,
     messages::MessageClient,
     plugin::{Element, ElementCreator, integrator::IntegratorElement},
 };
@@ -25,20 +25,18 @@ impl VerletInner {
         &mut self,
         entities: &[physim_core::Entity],
         new_state: &mut [physim_core::Entity],
-        forces: &[physim_core::Force],
+        accelerations: &[physim_core::Acceleration],
         dt: f64,
     ) {
         self.previous_state = entities.to_vec();
-        for (idx, (entity, f)) in entities.iter().zip(forces).enumerate() {
-            let m = entity.mass;
-            let a = [f.fx / m, f.fy / m, f.fz / m];
-            let x = entity.x + entity.vx * dt + 0.5 * a[0] * (dt.powi(2));
-            let y = entity.y + entity.vy * dt + 0.5 * a[1] * (dt.powi(2));
-            let z = entity.z + entity.vz * dt + 0.5 * a[2] * (dt.powi(2));
+        for (idx, (entity, a)) in entities.iter().zip(accelerations).enumerate() {
+            let x = entity.x + entity.vx * dt + 0.5 * a.x * (dt.powi(2));
+            let y = entity.y + entity.vy * dt + 0.5 * a.y * (dt.powi(2));
+            let z = entity.z + entity.vz * dt + 0.5 * a.z * (dt.powi(2));
 
-            let vx = entity.vx + a[0] * dt;
-            let vy = entity.vy + a[1] * dt;
-            let vz = entity.vz + a[2] * dt;
+            let vx = entity.vx + a.x * dt;
+            let vy = entity.vy + a.y * dt;
+            let vz = entity.vz + a.z * dt;
 
             let mut new_entity = *entity;
             new_entity.x = x;
@@ -55,16 +53,14 @@ impl VerletInner {
         &mut self,
         entities: &[physim_core::Entity],
         new_state: &mut [physim_core::Entity],
-        forces: &[physim_core::Force],
+        accelerations: &[physim_core::Acceleration],
         dt: f64,
     ) {
-        for (idx, (entity, f)) in entities.iter().zip(forces).enumerate() {
+        for (idx, (entity, a)) in entities.iter().zip(accelerations).enumerate() {
             let prev = self.previous_state.get(idx).unwrap();
-            let m = entity.mass;
-            let a = [f.fx / m, f.fy / m, f.fz / m];
-            let x = 2_f64 * entity.x - prev.x + a[0] * (dt.powi(2));
-            let y = 2_f64 * entity.y - prev.y + a[1] * (dt.powi(2));
-            let z = 2_f64 * entity.z - prev.z + a[2] * (dt.powi(2));
+            let x = 2_f64 * entity.x - prev.x + a.x * (dt.powi(2));
+            let y = 2_f64 * entity.y - prev.y + a.y * (dt.powi(2));
+            let z = 2_f64 * entity.z - prev.z + a.z * (dt.powi(2));
 
             let vx = (x - entity.x) / dt;
             let vy = (y - entity.y) / dt;
@@ -88,16 +84,16 @@ impl IntegratorElement for Verlet {
         &self,
         entities: &[physim_core::Entity],
         new_state: &mut [physim_core::Entity],
-        force_fn: &dyn Fn(&[Entity], &mut [Force]),
+        acc_fn: &dyn Fn(&[Entity], &mut [Acceleration]),
         dt: f64,
     ) {
-        let mut forces = vec![Force::zero(); entities.len()];
-        force_fn(entities, &mut forces);
+        let mut accelerations = vec![Acceleration::zero(); entities.len()];
+        acc_fn(entities, &mut accelerations);
         let mut inner = self.inner.lock().unwrap();
         if inner.previous_state.len() != entities.len() {
-            inner.initial_integration(entities, new_state, &forces, dt);
+            inner.initial_integration(entities, new_state, &accelerations, dt);
         } else {
-            inner.integration(entities, new_state, &forces, dt);
+            inner.integration(entities, new_state, &accelerations, dt);
         }
     }
 }

--- a/mechanics/src/impulse.rs
+++ b/mechanics/src/impulse.rs
@@ -4,34 +4,36 @@ use std::{
 };
 
 use physim_attribute::transform_element;
-use physim_core::{Entity, Force, messages::MessageClient, plugin::transform::TransformElement};
+use physim_core::{
+    Acceleration, Entity, messages::MessageClient, plugin::transform::TransformElement,
+};
 use serde_json::Value;
 
 #[transform_element(
     name = "impulse",
-    blurb = "Apply an impulse force to all particles on the initial iteration of the simulation."
+    blurb = "Apply an impulse acceleration to all particles on the initial iteration of the simulation."
 )]
 pub struct Impluse {
     should_pulse: AtomicBool,
-    force: Force,
+    acceleration: Acceleration,
 }
 
 impl TransformElement for Impluse {
-    fn transform(&self, _state: &[Entity], forces: &mut [Force]) {
+    fn transform(&self, _state: &[Entity], accelerations: &mut [Acceleration]) {
         if self.should_pulse.swap(false, Ordering::Relaxed) {
-            for f in forces {
-                *f += self.force;
+            for a in accelerations {
+                *a += self.acceleration;
             }
         }
     }
 
     fn new(properties: HashMap<String, Value>) -> Self {
-        let fx = properties.get("fx").and_then(|x| x.as_f64()).unwrap_or(0.0);
-        let fy = properties.get("fy").and_then(|x| x.as_f64()).unwrap_or(0.0);
-        let fz = properties.get("fz").and_then(|x| x.as_f64()).unwrap_or(0.0);
-        let force = Force { fx, fy, fz };
+        let x = properties.get("x").and_then(|x| x.as_f64()).unwrap_or(0.0);
+        let y = properties.get("y").and_then(|x| x.as_f64()).unwrap_or(0.0);
+        let z = properties.get("z").and_then(|x| x.as_f64()).unwrap_or(0.0);
+        let acceleration = Acceleration { x, y, z };
         Impluse {
-            force,
+            acceleration,
             should_pulse: AtomicBool::new(true),
         }
     }
@@ -45,16 +47,16 @@ impl TransformElement for Impluse {
     fn get_property_descriptions(&self) -> HashMap<String, String> {
         HashMap::from([
             (
-                String::from("fx"),
-                String::from("Force in x direction. Default=0.0"),
+                String::from("x"),
+                String::from("Acceleration in x direction. Default=0.0"),
             ),
             (
-                String::from("fy"),
-                String::from("Force in y direction. Default=0.0"),
+                String::from("y"),
+                String::from("Acceleration in y direction. Default=0.0"),
             ),
             (
-                String::from("fz"),
-                String::from("Force in z direction. Default=0.0"),
+                String::from("z"),
+                String::from("Acceleration in z direction. Default=0.0"),
             ),
         ])
     }

--- a/physim-core/src/lib.rs
+++ b/physim-core/src/lib.rs
@@ -35,62 +35,62 @@ pub struct Entity {
 
 #[derive(Clone, Copy, Default, Debug, Serialize)]
 #[repr(C)]
-pub struct Force {
-    pub fx: f64,
-    pub fy: f64,
-    pub fz: f64,
+pub struct Acceleration {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
 }
 
-impl Force {
+impl Acceleration {
     pub fn zero() -> Self {
         Self {
-            fx: 0.0,
-            fy: 0.0,
-            fz: 0.0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
         }
     }
 }
 
-impl Add for Force {
+impl Add for Acceleration {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
         Self {
-            fx: self.fx + rhs.fx,
-            fy: self.fy + rhs.fy,
-            fz: self.fz + rhs.fz,
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+            z: self.z + rhs.z,
         }
     }
 }
 
-impl AddAssign for Force {
+impl AddAssign for Acceleration {
     fn add_assign(&mut self, rhs: Self) {
-        self.fx += rhs.fx;
-        self.fy += rhs.fy;
-        self.fz += rhs.fz;
+        self.x += rhs.x;
+        self.y += rhs.y;
+        self.z += rhs.z;
     }
 }
 
-impl Sub for Force {
+impl Sub for Acceleration {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
         Self {
-            fx: self.fx - rhs.fx,
-            fy: self.fy - rhs.fy,
-            fz: self.fz - rhs.fz,
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+            z: self.z - rhs.z,
         }
     }
 }
 
-impl Neg for Force {
+impl Neg for Acceleration {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
         Self {
-            fx: -self.fx,
-            fy: -self.fy,
-            fz: -self.fz,
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
         }
     }
 }

--- a/physim-core/src/pipeline.rs
+++ b/physim-core/src/pipeline.rs
@@ -26,7 +26,7 @@ use crate::{
         transmute::{TransmuteElement, TransmuteElementHandler},
         ElementKind, Loadable, RegisteredElement,
     },
-    Entity, Force, UniverseConfiguration,
+    Acceleration, Entity, UniverseConfiguration,
 };
 
 use crate::msg;
@@ -95,11 +95,6 @@ impl Pipeline {
             new_state.push(Entity::default());
         }
 
-        // let mut forces = Vec::with_capacity(state.capacity());
-        // for _ in 0..state.len() {
-        //     forces.push(Force::default());
-        // }
-
         let msg_flag = Arc::new(AtomicBool::new(true));
         let msg_flag_clone = msg_flag.clone();
         let bus_clone = self.bus.clone();
@@ -116,10 +111,10 @@ impl Pipeline {
         thread::spawn(move || {
             let dt = self.timestep;
             let mut count = 0;
-            let transform_fn = |state: &[Entity], forces: &mut [Force]| {
+            let transform_fn = |state: &[Entity], accelerations: &mut [Acceleration]| {
                 self.transforms
                     .iter()
-                    .for_each(|element| element.transform(state, forces))
+                    .for_each(|element| element.transform(state, accelerations))
             };
 
             while count < self.iterations {

--- a/physim-core/src/plugin/integrator.rs
+++ b/physim-core/src/plugin/integrator.rs
@@ -1,4 +1,4 @@
-use crate::{messages::MessageClient, Entity, Force};
+use crate::{messages::MessageClient, Acceleration, Entity};
 
 use super::Element;
 
@@ -7,7 +7,7 @@ pub trait IntegratorElement: Element + Send + Sync {
         &self,
         entities: &[Entity],
         new_state: &mut [Entity],
-        force_fn: &dyn Fn(&[Entity], &mut [Force]),
+        acc_fn: &dyn Fn(&[Entity], &mut [Acceleration]),
         dt: f64,
     );
 }
@@ -21,10 +21,10 @@ impl IntegratorElement for IntegratorElementHandler {
         &self,
         entities: &[Entity],
         new_state: &mut [Entity],
-        force_fn: &dyn Fn(&[Entity], &mut [Force]),
+        acc_fn: &dyn Fn(&[Entity], &mut [Acceleration]),
         dt: f64,
     ) {
-        self.instance.integrate(entities, new_state, force_fn, dt);
+        self.instance.integrate(entities, new_state, acc_fn, dt);
     }
 }
 

--- a/physim_attribute/src/lib.rs
+++ b/physim_attribute/src/lib.rs
@@ -66,10 +66,10 @@ pub fn transform_element(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
 
         #[unsafe(no_mangle)]
-        pub unsafe extern "C" fn #transform_fn(obj: *const std::ffi::c_void, state: *const Entity, state_len: usize, forces: *mut Force, forces_len: usize) {
+        pub unsafe extern "C" fn #transform_fn(obj: *const std::ffi::c_void, state: *const Entity, state_len: usize, acceleration: *mut Acceleration, acceleration_len: usize) {
             let el: & #struct_name = unsafe { &*(obj as *const #struct_name) };
             let s =  unsafe { std::slice::from_raw_parts(state, state_len) };
-            let n =  unsafe {  std::slice::from_raw_parts_mut(forces, forces_len) };
+            let n =  unsafe {  std::slice::from_raw_parts_mut(acceleration, acceleration_len) };
             el.transform(s, n);
         }
 


### PR DESCRIPTION
The core library now handles accelerations rather than forces. The reason for this is to support different laws of physics as the original f=ma limits you to classical mechanics. This is a breaking change since the integrator and transform interfaces have both changed. The transform elements have been updated to calculate acceleration and the acceleration calculation has been removed from the integrators. This change effectively decouples integrators from physics.