### PR TITLE
feat!: Add fixed field to Entity

### DIFF
--- a/astro/src/initialisers.rs
+++ b/astro/src/initialisers.rs
@@ -7,10 +7,8 @@ use std::{collections::HashMap, f64::consts::PI, sync::Mutex};
 use physim_attribute::initialise_state_element;
 use physim_core::{
     Entity,
-    messages::{MessageClient, MessagePriority},
-    msg,
+    messages::MessageClient,
     plugin::{Element, ElementCreator, generator::GeneratorElement},
-    post_bus_msg,
 };
 use rand_chacha::{ChaCha8Rng, rand_core::SeedableRng};
 use serde_json::Value;
@@ -189,7 +187,6 @@ pub struct SingleStar {
 
 struct SingleStarInner {
     entity: Entity,
-    fixed: bool,
 }
 
 impl ElementCreator for SingleStar {
@@ -217,14 +214,13 @@ impl ElementCreator for SingleStar {
                 .get("id")
                 .and_then(|v| v.as_u64().map(|v| v as usize))
                 .unwrap_or(0),
+            fixed: properties
+                .get("fixed")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
         };
 
-        let fixed = properties
-            .get("fixed")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-
-        let inner = SingleStarInner { entity, fixed };
+        let inner = SingleStarInner { entity };
 
         Box::new(Self {
             inner: Mutex::new(inner),
@@ -237,15 +233,6 @@ impl MessageClient for SingleStar {}
 impl GeneratorElement for SingleStar {
     fn create_entities(&self) -> Vec<Entity> {
         let inner = self.inner.lock().unwrap();
-        if inner.fixed {
-            let pause = msg!(
-                self,
-                "astro.fixed",
-                format!("{}", inner.entity.id),
-                MessagePriority::RealTime
-            );
-            post_bus_msg!(pause);
-        }
         vec![inner.entity]
     }
 }
@@ -283,8 +270,7 @@ impl Element for SingleStar {
             inner.entity.id = 0
         }
         if let Some(val) = new_props.get("fixed").and_then(|val| val.as_bool()) {
-            println!("setting fixed!");
-            inner.fixed = val
+            inner.entity.fixed = val
         }
     }
 
@@ -300,7 +286,7 @@ impl Element for SingleStar {
             "m" => Ok(serde_json::json!(inner.entity.mass)),
             "r" => Ok(serde_json::json!(inner.entity.radius)),
             "id" => Ok(serde_json::json!(inner.entity.id)),
-            "fixed" => Ok(serde_json::json!(inner.fixed)),
+            "fixed" => Ok(serde_json::json!(inner.entity.fixed)),
             _ => Err("No property".into()),
         }
     }
@@ -554,16 +540,9 @@ impl GeneratorElement for SolarSystem {
             z: 0.5,
             radius: 0.2,
             mass: 1.0,
-            id: 9999,
+            fixed: true,
             ..Default::default()
         };
-        let fixed_msg = msg!(
-            self,
-            "astro.fixed",
-            format!("{}", sun.id),
-            MessagePriority::RealTime
-        );
-        post_bus_msg!(fixed_msg);
         let mut entities = vec![sun];
 
         let m_planets = rand_distr::LogNormal::new(1.1, 0.1)

--- a/astro/src/transformers.rs
+++ b/astro/src/transformers.rs
@@ -22,7 +22,6 @@ pub struct AstroElement {
 struct InnerBhElement {
     theta: f64,
     easing_factor: f64,
-    skip_ids: Vec<usize>,
 }
 
 impl TransformElement for AstroElement {
@@ -41,7 +40,7 @@ impl TransformElement for AstroElement {
         }
         let element = self.inner.lock().unwrap();
         for (i, star_a) in state.iter().enumerate() {
-            if element.skip_ids.contains(&star_a.id) {
+            if star_a.fixed {
                 continue;
             }
             let mut f = [0.0; 3];
@@ -81,7 +80,6 @@ impl TransformElement for AstroElement {
             inner: Mutex::new(InnerBhElement {
                 theta,
                 easing_factor,
-                skip_ids: vec![],
             }),
         }
     }
@@ -126,15 +124,7 @@ impl TransformElement for AstroElement {
     }
 }
 
-impl MessageClient for AstroElement {
-    fn recv_message(&self, message: physim_core::messages::Message) {
-        if message.topic == "astro.fixed" {
-            let id = message.message.parse().unwrap();
-            let mut lock = self.inner.lock().unwrap();
-            lock.skip_ids.push(id);
-        }
-    }
-}
+impl MessageClient for AstroElement {}
 
 #[transform_element(
     name = "astro2",
@@ -161,7 +151,7 @@ impl TransformElement for AstroOctreeElement {
 
         let element = self.inner.lock().unwrap();
         for (i, star_a) in state.iter().enumerate() {
-            if element.skip_ids.contains(&star_a.id) {
+            if star_a.fixed {
                 continue;
             }
             let mut f = [0.0; 3];
@@ -200,7 +190,6 @@ impl TransformElement for AstroOctreeElement {
             inner: Mutex::new(InnerBhElement {
                 theta,
                 easing_factor,
-                skip_ids: vec![],
             }),
         }
     }
@@ -245,15 +234,7 @@ impl TransformElement for AstroOctreeElement {
     }
 }
 
-impl MessageClient for AstroOctreeElement {
-    fn recv_message(&self, message: physim_core::messages::Message) {
-        if message.topic == "astro.fixed" {
-            let id = message.message.parse().unwrap();
-            let mut lock = self.inner.lock().unwrap();
-            lock.skip_ids.push(id);
-        }
-    }
-}
+impl MessageClient for AstroOctreeElement {}
 
 // impl Configurable for
 
@@ -267,14 +248,13 @@ pub struct SimpleAstroElement {
 
 struct InnerSimpleAstroElement {
     easing_factor: f64,
-    skip_ids: Vec<usize>,
 }
 
 impl TransformElement for SimpleAstroElement {
     fn transform(&self, state: &[Entity], accelerations: &mut [Acceleration]) {
         let inner = self.inner.lock().unwrap();
         for (i, star_a) in state.iter().enumerate() {
-            if inner.skip_ids.contains(&star_a.id) {
+            if star_a.fixed {
                 continue;
             }
             let mut f = [0.0; 3];
@@ -304,10 +284,7 @@ impl TransformElement for SimpleAstroElement {
             .unwrap_or(1.0);
 
         Self {
-            inner: Mutex::new(InnerSimpleAstroElement {
-                easing_factor,
-                skip_ids: vec![],
-            }),
+            inner: Mutex::new(InnerSimpleAstroElement { easing_factor }),
         }
     }
 
@@ -336,12 +313,4 @@ impl TransformElement for SimpleAstroElement {
     }
 }
 
-impl MessageClient for SimpleAstroElement {
-    fn recv_message(&self, message: physim_core::messages::Message) {
-        if message.topic == "astro.fixed" {
-            let id = message.message.parse().unwrap();
-            let mut lock = self.inner.lock().unwrap();
-            lock.skip_ids.push(id);
-        }
-    }
-}
+impl MessageClient for SimpleAstroElement {}

--- a/physim-core/src/lib.rs
+++ b/physim-core/src/lib.rs
@@ -31,6 +31,7 @@ pub struct Entity {
     pub radius: f64,
     pub mass: f64,
     pub id: usize,
+    pub fixed: bool,
 }
 
 #[derive(Clone, Copy, Default, Debug, Serialize)]


### PR DESCRIPTION
Entity now has a boolean fixed field. By default, it is false. If true, elements can use this field to ignore it. An example of this is keeping a black hole in the centre of the universe. Before, the message bus and the entity id were used to implement this behaviour. This is marked as a break change since entity has a new public field and the ABI is changed, meaning all plugins must be recompiled with this version of the library

BREAKING: Added fixed boolean parameter to Entity struct, breaking ABI