### PR TITLE
feat!:remove UniverseConfiguration

### DIFF
--- a/debug/src/energysink.rs
+++ b/debug/src/energysink.rs
@@ -33,11 +33,7 @@ impl ElementCreator for EnergySink {
 }
 
 impl RenderElement for EnergySink {
-    fn render(
-        &self,
-        _config: physim_core::UniverseConfiguration,
-        state_recv: std::sync::mpsc::Receiver<Vec<Entity>>,
-    ) {
+    fn render(&self, state_recv: std::sync::mpsc::Receiver<Vec<Entity>>) {
         let mut initial_energy = 0.0;
         if let Ok(state) = state_recv.recv() {
             let iteration = self.iteration.fetch_add(1, Ordering::Relaxed);

--- a/debug/src/lib.rs
+++ b/debug/src/lib.rs
@@ -138,11 +138,7 @@ impl ElementCreator for FakeSink {
 }
 
 impl RenderElement for FakeSink {
-    fn render(
-        &self,
-        _config: physim_core::UniverseConfiguration,
-        state_recv: std::sync::mpsc::Receiver<Vec<Entity>>,
-    ) {
+    fn render(&self, state_recv: std::sync::mpsc::Receiver<Vec<Entity>>) {
         while state_recv.recv().is_ok() {
             info!("Fake Rendering!");
             let large_message = "x".repeat(10_000_000);

--- a/physim-core/src/lib.rs
+++ b/physim-core/src/lib.rs
@@ -13,14 +13,6 @@ use std::ops::{Add, AddAssign, Neg, Sub};
 use rand::Rng;
 use rand_chacha::ChaCha8Rng;
 
-#[repr(C)]
-pub struct UniverseConfiguration {
-    pub size_x: f64,
-    pub size_y: f64,
-    pub size_z: f64,
-    // edge_mode: UniverseEdge,
-}
-
 #[derive(Clone, Copy, Default, Debug, PartialEq)]
 #[repr(C)]
 pub struct Entity {

--- a/physim-core/src/pipeline.rs
+++ b/physim-core/src/pipeline.rs
@@ -26,7 +26,7 @@ use crate::{
         transmute::{TransmuteElement, TransmuteElementHandler},
         ElementKind, Loadable, RegisteredElement,
     },
-    Acceleration, Entity, UniverseConfiguration,
+    Acceleration, Entity,
 };
 
 use crate::msg;
@@ -73,12 +73,6 @@ impl MessageClient for PipelineMessageClient {
 
 impl Pipeline {
     pub fn run(self) -> Result<(), String> {
-        let config = UniverseConfiguration {
-            size_x: 2.0,
-            size_y: 1.0,
-            size_z: 1.0,
-        };
-
         // cannot be reference since it'd break renderer
         let pipeline_messages = Arc::new(PipelineMessageClient::new());
         match self.bus.lock() {
@@ -197,7 +191,7 @@ impl Pipeline {
             }
         });
 
-        self.render.render(config, renderer_receiver);
+        self.render.render(renderer_receiver);
         msg_flag.store(false, std::sync::atomic::Ordering::Relaxed);
         message_thread
             .join()

--- a/physim-core/src/plugin/render.rs
+++ b/physim-core/src/plugin/render.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, error::Error, sync::mpsc::Receiver};
 
-use crate::{messages::MessageClient, Entity, UniverseConfiguration};
+use crate::{messages::MessageClient, Entity};
 
 use super::Element;
 
 pub trait RenderElement: Element + Send + Sync + MessageClient {
-    fn render(&self, config: UniverseConfiguration, state_recv: Receiver<Vec<Entity>>);
+    fn render(&self, state_recv: Receiver<Vec<Entity>>);
 }
 pub struct RenderElementHandler {
     instance: Box<dyn RenderElement>,
@@ -20,8 +20,8 @@ impl super::Loadable for RenderElementHandler {
 }
 
 impl RenderElementHandler {
-    pub fn render(&self, config: UniverseConfiguration, state_recv: Receiver<Vec<Entity>>) {
-        self.instance.render(config, state_recv);
+    pub fn render(&self, state_recv: Receiver<Vec<Entity>>) {
+        self.instance.render(state_recv);
     }
 }
 

--- a/utilities/src/csvsink.rs
+++ b/utilities/src/csvsink.rs
@@ -41,11 +41,7 @@ impl ElementCreator for CsvSink {
 }
 
 impl RenderElement for CsvSink {
-    fn render(
-        &self,
-        _config: physim_core::UniverseConfiguration,
-        state_recv: std::sync::mpsc::Receiver<Vec<Entity>>,
-    ) {
+    fn render(&self, state_recv: std::sync::mpsc::Receiver<Vec<Entity>>) {
         let res = File::options()
             .create(true)
             .write(true)


### PR DESCRIPTION
The render API no longer requires this struct to be passed in. It has been removed from the core library. It was only required for configuring the glrender plugin, and all functionality that you'd want is provided via other configuration option. This was literally just to configure the view-port and these basically have been constants since day 1 of this project.